### PR TITLE
chore: add mqtt command line argumuent to marilib service

### DIFF
--- a/examples/raspberry-pi/setup_marilib_service.sh
+++ b/examples/raspberry-pi/setup_marilib_service.sh
@@ -29,8 +29,7 @@ ExecStartPre=/usr/bin/udevadm settle
 ExecStartPre=/bin/bash -c "for i in {1..600}; do exec 3<>/dev/ttyACM10 && exit 0 || sleep 0.2; done; echo 'Gateway port: ttyACM10 not ready, the service has stopped and will not restart, check connections and reboot' >&2; exit 1"
 
 #run basic.py
-ExecStart=/usr/bin/tmux new-session -s marilib -d "/home/pi/marilib/venv/bin/python /home/pi/marilib/examples/mari_edge.py -p /dev/ttyACM10"
-ExecStop=/usr/bin/tmux kill-session -t marilib
+ExecStart=/usr/bin/tmux new-session -s marilib -d "/home/pi/marilib/venv/bin/python /home/pi/marilib/examples/mari_edge.py -m mqtts://argus.paris.inria.fr:8883 -p /dev/ttyACM10"
 Type=forking
 
 Restart=on-failure


### PR DESCRIPTION
## Description

<!-- Provide a short summary of the changes in this PR. -->

I changed the command to run TUI in the service adding mqtt command line argument
---

## Testing of Node / Gateway (if applicable)

- I tested this change with  1 nodes and  2 gateways.
- I let it run for the following amount of time: 5 minutes and tried it 4 times
- I tried it on the Raspberry Pi as part of the service or run manually, and on my computer

---

## Additional Notes

without the MQTT argument the TUI doesn't 