### PR TITLE
Chore: rename package so pypi is happy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,9 @@ exclude = [
 path = "marilib/__init__.py"
 
 [project]
-name = "marilib"
+# pypi complains that "the name 'marilib' is too similar to other packages"
+# so we use a -pkg postfix to circunvent that
+name = "marilib-pkg"
 dynamic = ["version"]
 authors = [
     { name="Geovane Fedrecheski", email="geovane.fedrecheski@inria.fr" },


### PR DESCRIPTION
## Description

As title says. 

This only impacts the name on pypi, e.g. installing will be `pip install marilib-pkg`, but usage in a .py file will still be `import marilib ...`