### PR TITLE
Enable metrics for Raspberry Pi example (every 5 s)

### DIFF
--- a/examples/raspberry-pi/setup_marilib_service.sh
+++ b/examples/raspberry-pi/setup_marilib_service.sh
@@ -29,7 +29,7 @@ ExecStartPre=/usr/bin/udevadm settle
 ExecStartPre=/bin/bash -c "for i in {1..600}; do exec 3<>/dev/ttyACM10 && exit 0 || sleep 0.2; done; echo 'Gateway port: ttyACM10 not ready, the service has stopped and will not restart, check connections and reboot' >&2; exit 1"
 
 #run basic.py
-ExecStart=/usr/bin/tmux new-session -s marilib -d "/home/pi/marilib/venv/bin/python /home/pi/marilib/examples/mari_edge.py -m mqtts://argus.paris.inria.fr:8883 -p /dev/ttyACM10"
+ExecStart=/usr/bin/tmux new-session -s marilib -d "/home/pi/marilib/venv/bin/python /home/pi/marilib/examples/mari_edge.py -m mqtts://argus.paris.inria.fr:8883 -p /dev/ttyACM10 --metrics-probe-interval 5"
 Type=forking
 
 Restart=on-failure


### PR DESCRIPTION
## Description

This is so the testbed will always report statistics. 

---

## Testing of Node / Gateway (if applicable)

- I tested this change with `___` nodes and `___` gateways.
- I let it run for the following amount of time: `___`

---

## Additional Notes

<!-- Add any additional info, screenshots, logs, or context here. -->
