### PR TITLE
marilib_edge: properly disable metrics probe by default

### DIFF
--- a/marilib/marilib_edge.py
+++ b/marilib/marilib_edge.py
@@ -44,7 +44,7 @@ class MarilibEdge(MarilibBase):
     gateway: MariGateway = field(default_factory=MariGateway)
     lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
     metrics_tester: MetricsTester | None = None
-    metrics_probe_period: float | None = None
+    metrics_probe_period: float = 0
 
     started_ts: datetime = field(default_factory=datetime.now)
     last_received_serial_data_ts: datetime = field(default_factory=datetime.now)


### PR DESCRIPTION
## Description

This should fix #73 

---

## Testing of Node / Gateway (if applicable)

This is 100% untested

---

## Additional Notes

<!-- Add any additional info, screenshots, logs, or context here. -->
