### PR TITLE
Improve TUI and latency calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,37 @@ To run with a gateway connected via MQTT:
 (.venv) $ mari-cloud -n 0x0100 -m mqtts://argus.paris.inria.fr:8883
 ```
 
+### Reading the TUI
+
+Most columns in the per-node table are self-explanatory (TX/RX
+counts, PDR, RSSI). The two that need a key:
+
+- **Latency | host/dl/app/ul (ms)** — total host-measured round-trip
+  latency on the left of the bar, then the four-leg breakdown that
+  sums (≈) to it:
+  - `host` — UART round-trip plus Python parse overhead (typically
+    10–30 ms at 1 Mbps; sustained higher means host-side congestion).
+  - `dl` — gateway downlink-queue wait plus one radio slot.
+  - `app` — node-side application turnaround (e.g. how long the
+    SwarmIT network-core main loop takes between receiving the probe
+    and enqueueing the response).
+  - `ul` — node uplink-queue wait plus one radio slot. **This is the
+    leg that grows when the node is saturating its uplink budget.**
+
+  Wire legs come from ASN snapshots the firmware stamps into each
+  probe (`gw_tx_enqueued_asn`, `node_rx_asn`,
+  `node_tx_enqueued_asn`, `gw_rx_asn`) converted via the slot
+  duration (1.724 ms in the shipped schedules). When the firmware
+  hasn't populated the wire ASNs the row shows `total | ? / ? / ? / ?`.
+
+- **Q (sf)** — estimated TX-queue depth at the node in **slotframe**
+  units. Each joined node has exactly one uplink slot per slotframe,
+  so `ul_ms / sf_duration_ms` is the number of packets queued ahead
+  of the probe response when it was enqueued. Coloring: white below
+  2 (healthy), yellow at 2–4 (contended), red above 4 (saturated).
+  The header panel also shows a `⚠ TX queue saturated` line when any
+  node crosses the red threshold.
+
 ## Setup and dependencies
 To setup the environment, do:
 

--- a/marilib/communication_adapter.py
+++ b/marilib/communication_adapter.py
@@ -71,9 +71,7 @@ class SerialAdapter(CommunicationAdapterBase):
             if late_stamp_offset is not None:
                 data = bytearray(data)
                 stamp_us = time.monotonic_ns() // 1000
-                data[late_stamp_offset : late_stamp_offset + 8] = stamp_us.to_bytes(
-                    8, "little"
-                )
+                data[late_stamp_offset : late_stamp_offset + 8] = stamp_us.to_bytes(8, "little")
             self.serial.serial.flush()
             encoded = hdlc_encode(data)
             self.serial.write(encoded)

--- a/marilib/communication_adapter.py
+++ b/marilib/communication_adapter.py
@@ -1,4 +1,5 @@
 import base64
+import time
 from urllib.parse import urlparse
 import paho.mqtt.client as mqtt
 
@@ -37,10 +38,14 @@ class SerialAdapter(CommunicationAdapterBase):
     def on_byte_received(self, byte):
         self.hdlc_handler.handle_byte(byte)
         if self.hdlc_handler.state == HDLCState.READY:
+            # Capture the RX timestamp as close to wire-arrival as we
+            # can — before downstream callbacks acquire mari.lock,
+            # which can be held by render_tui / update for tens of ms
+            # and would otherwise inflate measured RTT.
+            rx_ts_us = time.monotonic_ns() // 1000
             try:
                 payload = self.hdlc_handler.payload
-                # print(f"Received payload: {payload.hex()}")
-                self.on_data_received(payload)
+                self.on_data_received(payload, rx_ts_us)
             except HDLCDecodeException as e:
                 print(f"Error decoding payload: {e}")
 
@@ -52,8 +57,23 @@ class SerialAdapter(CommunicationAdapterBase):
     def close(self):
         print("[yellow]Disconnect from gateway...[/]")
 
-    def send_data(self, data):
+    def send_data(self, data, late_stamp_offset: int | None = None):
+        """Write data over the UART.
+
+        If `late_stamp_offset` is given, overwrite
+        bytes[late_stamp_offset : late_stamp_offset + 8] of `data` with
+        time.monotonic_ns() // 1000 as little-endian uint64 AFTER the
+        serial lock is acquired and just before HDLC encoding. Used by
+        metrics probes to capture their TX timestamp as close to
+        wire-departure as possible.
+        """
         with self.serial.lock:  # Use the existing lock for thread safety
+            if late_stamp_offset is not None:
+                data = bytearray(data)
+                stamp_us = time.monotonic_ns() // 1000
+                data[late_stamp_offset : late_stamp_offset + 8] = stamp_us.to_bytes(
+                    8, "little"
+                )
             self.serial.serial.flush()
             encoded = hdlc_encode(data)
             self.serial.write(encoded)

--- a/marilib/mari_protocol.py
+++ b/marilib/mari_protocol.py
@@ -8,6 +8,12 @@ MARI_PROTOCOL_VERSION = 2
 MARI_BROADCAST_ADDRESS = 0xFFFFFFFFFFFFFFFF
 MARI_NET_ID_DEFAULT = 0x0001
 
+# Mari slot duration in ms. From fedrecheski26mari.pdf §3.4 and Table 1:
+# all four shipped schedules have ~1.7 ms slots (huge: 256.88 ms /
+# 149 slots = 1.7240 ms; the others come out to the same value within
+# rounding). Used to convert ASN deltas in MetricsProbePayload to ms.
+MARI_SLOT_DURATION_MS = 1.7240
+
 
 class DefaultPayloadType(IntEnum):
     APPLICATION_DATA = 0x01
@@ -96,6 +102,57 @@ class MetricsProbePayload(Packet):
 
     def latency_roundtrip_node_cloud_ms(self) -> float:
         return (self.cloud_rx_ts_us - self.cloud_tx_ts_us) / 1000.0
+
+    # ----------------------- ASN-decomposed latency -----------------------
+    # The probe carries ASN snapshots taken at the gateway and the node.
+    # Multiplied by MARI_SLOT_DURATION_MS, ASN deltas tell us where the
+    # RTT went in slot-time:
+    #
+    #   dl half = node_rx_asn - gw_tx_enqueued_asn
+    #             (gateway downlink-queue wait + 1 radio slot)
+    #   app     = node_tx_enqueued_asn - node_rx_asn
+    #             (swarmit netcore main-loop turnaround)
+    #   ul half = gw_rx_asn - node_tx_enqueued_asn
+    #             (node uplink-queue wait + 1 radio slot)
+    #
+    # Note: gw_tx_dequeued_asn and node_tx_dequeued_asn are declared in
+    # mari/models.h but never written by the firmware, so we can't isolate
+    # the queue wait from the radio-slot fire — both are folded into the
+    # 'dl half' and 'ul half' figures. See docs/mari-protocol-summary.md.
+
+    def _asn_delta_ms(self, end_asn: int, start_asn: int) -> float:
+        """Convert end-start ASN to ms. Returns 0.0 for missing samples
+        (any ASN == 0) or non-monotonic pairs (end <= start, which can
+        happen on the first probe before counters have rolled in)."""
+        if not end_asn or not start_asn or end_asn <= start_asn:
+            return 0.0
+        return (end_asn - start_asn) * MARI_SLOT_DURATION_MS
+
+    def downlink_half_ms(self) -> float:
+        """Gateway-enqueue to node-receive. Includes the gateway's
+        downlink-queue wait plus one radio slot."""
+        return self._asn_delta_ms(self.node_rx_asn, self.gw_tx_enqueued_asn)
+
+    def node_processing_ms(self) -> float:
+        """Node app-side turnaround: node-receive to node-enqueue. In
+        the swarmit firmware, this is the time the netcore main loop
+        takes to process the probe and queue the response."""
+        return self._asn_delta_ms(self.node_tx_enqueued_asn, self.node_rx_asn)
+
+    def uplink_half_ms(self) -> float:
+        """Node-enqueue to gateway-receive. Includes the node's
+        uplink-queue wait plus one radio slot. This is where queue
+        backpressure at the node will show up."""
+        return self._asn_delta_ms(self.gw_rx_asn, self.node_tx_enqueued_asn)
+
+    def wire_rtt_ms(self) -> float:
+        """Total wire round-trip in slot-time = dl + app + ul. Should be
+        close to host-measured RTT minus UART + Python overhead (~15-30 ms)."""
+        return (
+            self.downlink_half_ms()
+            + self.node_processing_ms()
+            + self.uplink_half_ms()
+        )
 
     def pdr_saturated(self, count_a: int, count_b: int) -> float:
         if count_b == 0:

--- a/marilib/mari_protocol.py
+++ b/marilib/mari_protocol.py
@@ -148,11 +148,7 @@ class MetricsProbePayload(Packet):
     def wire_rtt_ms(self) -> float:
         """Total wire round-trip in slot-time = dl + app + ul. Should be
         close to host-measured RTT minus UART + Python overhead (~15-30 ms)."""
-        return (
-            self.downlink_half_ms()
-            + self.node_processing_ms()
-            + self.uplink_half_ms()
-        )
+        return self.downlink_half_ms() + self.node_processing_ms() + self.uplink_half_ms()
 
     def pdr_saturated(self, count_a: int, count_b: int) -> float:
         if count_b == 0:

--- a/marilib/marilib_edge.py
+++ b/marilib/marilib_edge.py
@@ -238,9 +238,7 @@ class MarilibEdge(MarilibBase):
 
                     # handle metrics probe packets
                     if frame.is_test_packet:
-                        payload = self.metrics_tester.handle_response_edge(
-                            frame, rx_ts_us
-                        )
+                        payload = self.metrics_tester.handle_response_edge(frame, rx_ts_us)
                         if payload:
                             frame.payload = payload.to_bytes()
 

--- a/marilib/marilib_edge.py
+++ b/marilib/marilib_edge.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Any, Callable
 from rich import print
 
-from marilib.metrics import MetricsTester
+from marilib.metrics import EDGE_TX_TS_WIRE_OFFSET, MetricsTester
 from marilib.mari_protocol import (
     MARI_BROADCAST_ADDRESS,
     Frame,
@@ -102,6 +102,31 @@ class MarilibEdge(MarilibBase):
             EdgeEvent.to_bytes(EdgeEvent.NODE_DATA) + mari_frame.to_bytes()
         )
 
+    def send_probe(self, dst: int, payload: bytes):
+        """Send a metrics probe with edge_tx_ts_us stamped at wire-departure.
+
+        Identical wire format to send_frame, but edge_tx_ts_us is
+        overwritten with a fresh monotonic timestamp inside the serial
+        adapter's lock, just before the bytes leave the UART. This
+        avoids inflating measured RTT with Python-side lock contention
+        (mari.lock during render_tui, update, etc.). The caller MUST
+        place edge_tx_ts_us within `payload` at the offset assumed by
+        EDGE_TX_TS_WIRE_OFFSET — currently only MetricsTester does.
+        """
+        assert self.serial_interface is not None
+
+        mari_frame = Frame(Header(destination=dst), payload=payload)
+
+        with self.lock:
+            self.gateway.register_sent_frame(mari_frame)
+            if n := self.gateway.get_node(dst):
+                n.register_sent_frame(mari_frame)
+
+        self.serial_interface.send_data(
+            EdgeEvent.to_bytes(EdgeEvent.NODE_DATA) + mari_frame.to_bytes(),
+            late_stamp_offset=EDGE_TX_TS_WIRE_OFFSET,
+        )
+
     def render_tui(self):
         if self.tui:
             self.tui.render(self)
@@ -158,9 +183,15 @@ class MarilibEdge(MarilibBase):
             return
         self.send_frame(frame.header.destination, frame.payload)
 
-    def handle_serial_data(self, data: bytes) -> tuple[bool, EdgeEvent, Any]:
+    def handle_serial_data(
+        self, data: bytes, rx_ts_us: int | None = None
+    ) -> tuple[bool, EdgeEvent, Any]:
         """
         Handles the serial data received from the radio gateway.
+
+        `rx_ts_us` is the monotonic-microsecond timestamp captured by
+        the serial adapter at HDLC-READY (wire arrival). Passed through
+        to handle_response_edge for accurate edge_rx_ts_us stamping.
         """
         if len(data) < 1:
             return False, EdgeEvent.UNKNOWN, None
@@ -207,7 +238,9 @@ class MarilibEdge(MarilibBase):
 
                     # handle metrics probe packets
                     if frame.is_test_packet:
-                        payload = self.metrics_tester.handle_response_edge(frame)
+                        payload = self.metrics_tester.handle_response_edge(
+                            frame, rx_ts_us
+                        )
                         if payload:
                             frame.payload = payload.to_bytes()
 
@@ -217,8 +250,8 @@ class MarilibEdge(MarilibBase):
 
         return False, event_type, None
 
-    def on_serial_data_received(self, data: bytes):
-        res, event_type, event_data = self.handle_serial_data(data)
+    def on_serial_data_received(self, data: bytes, rx_ts_us: int | None = None):
+        res, event_type, event_data = self.handle_serial_data(data, rx_ts_us)
         if not res:
             return
 

--- a/marilib/metrics.py
+++ b/marilib/metrics.py
@@ -11,6 +11,31 @@ if TYPE_CHECKING:
     from marilib.marilib_edge import MarilibEdge
 
 
+# Wire-byte offset of edge_tx_ts_us in an outbound probe frame:
+#   1 byte EdgeEvent prefix + 20-byte Header + 1-byte HeaderStats +
+#   offset of edge_tx_ts_us within MetricsProbePayload.
+# Used by MarilibEdge.send_probe to overwrite this field with a fresh
+# monotonic timestamp inside the serial-adapter lock, just before the
+# bytes leave the UART.
+EDGE_TX_TS_WIRE_OFFSET = (
+    1
+    + 20
+    + 1
+    + sum(
+        f.length
+        for f in MetricsProbePayload().metadata
+        if f.name
+        in {
+            "type",
+            "cloud_tx_ts_us",
+            "cloud_rx_ts_us",
+            "cloud_tx_count",
+            "cloud_rx_count",
+        }
+    )
+)
+
+
 class MetricsTester:
     """A thread-based class to periodically test metrics to all nodes."""
 
@@ -62,27 +87,49 @@ class MetricsTester:
                 self._stop_event.wait(sleep_duration)
 
     def timestamp_us(self) -> int:
-        """Returns the current time in microseconds."""
-        return int(time.time() * 1000 * 1000)
+        """Returns a monotonic timestamp in microseconds.
+
+        Monotonic (not wall-clock), so an NTP step adjustment cannot
+        create apparent jumps in measured latency. Edge stamps both
+        ends of the probe round trip with the same clock; the node
+        firmware echoes edge_tx_ts_us back unchanged as an opaque
+        8-byte blob.
+        """
+        return time.monotonic_ns() // 1000
 
     def send_metrics_request(self, node: MariNode, marilib_type: str):
         """Sends a metrics request packet to a specific address."""
         payload = MetricsProbePayload()
         if marilib_type == "edge":
-            payload.edge_tx_ts_us = self.timestamp_us()
+            # Leave edge_tx_ts_us as 0; MarilibEdge.send_probe overwrites
+            # it with a monotonic timestamp inside the serial lock, right
+            # before the bytes leave the UART — avoids inflating the
+            # measured RTT with mari.lock contention from render_tui /
+            # update / other send_frame calls.
             payload.edge_tx_count = node.probe_increment_tx_count()
+            payload_bytes = payload.to_bytes()
+            self.marilib.send_probe(node.address, payload_bytes)
         elif marilib_type == "cloud":
+            # Cloud probes are still stamped on call (MQTT publish is
+            # async and the cloud's MetricsTester is currently never
+            # started — marilib_cloud.py:55-57 — so this path is unused).
             payload.cloud_tx_ts_us = self.timestamp_us()
             payload.cloud_tx_count = node.probe_increment_tx_count()
-        # print(f">>> sending metrics probe to {node.address:016x}: {payload}")
-        payload = payload.to_bytes()
-        # print(f"    size is {len(payload)} bytes: {payload.hex()}\n")
-        self.marilib.send_frame(node.address, payload)
+            payload_bytes = payload.to_bytes()
+            self.marilib.send_frame(node.address, payload_bytes)
 
-    def handle_response_edge(self, frame: Frame):
+    def handle_response_edge(self, frame: Frame, rx_ts_us: int | None = None):
         """
         Processes a metrics response frame.
         This should be called when a LATENCY_DATA event is received.
+
+        `rx_ts_us` is the monotonic-microsecond timestamp captured by
+        the serial adapter when the HDLC frame became READY (i.e.
+        right after the wire bytes arrived). When supplied, it's used
+        as edge_rx_ts_us instead of stamping here — handler runs
+        inside mari.lock, which can be held by render_tui / update /
+        send_frame for tens of ms, so stamping here would inflate the
+        measured RTT.
         """
         node = self.marilib.gateway.get_node(frame.header.source)
         if not node:
@@ -99,7 +146,9 @@ class MetricsTester:
             print(f"[red]Error parsing metrics response: {e}[/]")
             return
 
-        payload.edge_rx_ts_us = self.timestamp_us()
+        payload.edge_rx_ts_us = (
+            rx_ts_us if rx_ts_us is not None else self.timestamp_us()
+        )
         payload.edge_rx_count = node.probe_increment_rx_count()
 
         node.save_probe_stats(payload)

--- a/marilib/metrics.py
+++ b/marilib/metrics.py
@@ -3,24 +3,43 @@ import time
 from typing import TYPE_CHECKING
 
 from rich import print
-from marilib.mari_protocol import Frame, DefaultPayloadType
-from marilib.mari_protocol import MetricsProbePayload
+from marilib.mari_protocol import (
+    DefaultPayloadType,
+    Frame,
+    Header,
+    HeaderStats,
+    MetricsProbePayload,
+)
 from marilib.model import MariGateway, MariNode, MARI_PROBE_STATS_MAX_LEN
 
 if TYPE_CHECKING:
     from marilib.marilib_edge import MarilibEdge
 
 
-# Wire-byte offset of edge_tx_ts_us in an outbound probe frame:
-#   1 byte EdgeEvent prefix + 20-byte Header + 1-byte HeaderStats +
-#   offset of edge_tx_ts_us within MetricsProbePayload.
-# Used by MarilibEdge.send_probe to overwrite this field with a fresh
-# monotonic timestamp inside the serial-adapter lock, just before the
-# bytes leave the UART.
+# Wire-byte offset of edge_tx_ts_us in an outbound probe frame.
+# Layout of the bytes that MarilibEdge.send_probe hands to the serial
+# adapter:
+#   [1 byte EdgeEvent prefix]   (prepended by send_probe;
+#                                EdgeEvent.NODE_DATA in EdgeEvent.to_bytes)
+#   [Header bytes]              (sum of Header().metadata field lengths,
+#                                today 20: version + type_ + network_id
+#                                + dst + src)
+#   [HeaderStats bytes]         (sum of HeaderStats().metadata field
+#                                lengths, today 1: rssi)
+#   [MetricsProbePayload bytes] (the fields preceding edge_tx_ts_us in
+#                                MetricsProbePayload().metadata: type,
+#                                cloud_tx_ts_us, cloud_rx_ts_us,
+#                                cloud_tx_count, cloud_rx_count, today 25)
+# Only the leading 1 byte (EdgeEvent prefix) is a literal; the rest is
+# derived from the dataclass metadata so the offset survives any
+# reordering of the Mari header or probe layout.
+# Used by MarilibEdge.send_probe to overwrite edge_tx_ts_us with a
+# fresh monotonic timestamp inside the serial-adapter lock, just
+# before the bytes leave the UART.
 EDGE_TX_TS_WIRE_OFFSET = (
     1
-    + 20
-    + 1
+    + sum(f.length for f in Header().metadata)
+    + sum(f.length for f in HeaderStats().metadata)
     + sum(
         f.length
         for f in MetricsProbePayload().metadata
@@ -146,9 +165,7 @@ class MetricsTester:
             print(f"[red]Error parsing metrics response: {e}[/]")
             return
 
-        payload.edge_rx_ts_us = (
-            rx_ts_us if rx_ts_us is not None else self.timestamp_us()
-        )
+        payload.edge_rx_ts_us = rx_ts_us if rx_ts_us is not None else self.timestamp_us()
         payload.edge_rx_count = node.probe_increment_rx_count()
 
         node.save_probe_stats(payload)

--- a/marilib/model.py
+++ b/marilib/model.py
@@ -365,9 +365,7 @@ class MariNode:
         return self._avg_nonzero([p.downlink_half_ms() for p in self.probe_stats])
 
     def stats_avg_node_processing_ms(self) -> float:
-        return self._avg_nonzero(
-            [p.node_processing_ms() for p in self.probe_stats]
-        )
+        return self._avg_nonzero([p.node_processing_ms() for p in self.probe_stats])
 
     def stats_avg_uplink_half_ms(self) -> float:
         return self._avg_nonzero([p.uplink_half_ms() for p in self.probe_stats])
@@ -571,9 +569,7 @@ class MariGateway:
         return self._avg_node_metric_nonzero(MariNode.stats_avg_downlink_half_ms)
 
     def stats_avg_node_processing_ms(self) -> float:
-        return self._avg_node_metric_nonzero(
-            MariNode.stats_avg_node_processing_ms
-        )
+        return self._avg_node_metric_nonzero(MariNode.stats_avg_node_processing_ms)
 
     def stats_avg_uplink_half_ms(self) -> float:
         return self._avg_node_metric_nonzero(MariNode.stats_avg_uplink_half_ms)

--- a/marilib/model.py
+++ b/marilib/model.py
@@ -407,21 +407,6 @@ class MariNode:
             return 0.0
         return self.stats_avg_uplink_half_ms() / sf_duration_ms
 
-    def stats_uplink_utilization(self, sf_duration_ms: float) -> float:
-        """Fraction of this node's max sustainable uplink rate currently used.
-
-        max_pps_per_node = 1000 / sf_duration_ms (one U slot per
-        slotframe in the current shipped schedules). Observed pps is
-        the 1-second RX rate at the edge, which equals the drain rate
-        from the node's TX queue. >0.9 means the node is at or near
-        saturation: any extra production will pile up in the queue.
-        """
-        if sf_duration_ms <= 0:
-            return 0.0
-        max_pps = 1000.0 / sf_duration_ms
-        observed_pps = self.stats.received_count(1, include_test_packets=True)
-        return observed_pps / max_pps
-
     def register_received_frame(self, frame: Frame):
         self.stats.add_received(frame)
 

--- a/marilib/model.py
+++ b/marilib/model.py
@@ -352,6 +352,76 @@ class MariNode:
             return 0
         return self.probe_stats_latest.latency_roundtrip_node_cloud_ms()
 
+    # ASN-decomposed latency aggregates. Each averages over the
+    # probe_stats deque, ignoring samples where the relevant ASN pair
+    # is missing or non-monotonic (returns 0.0 from the underlying
+    # MetricsProbePayload helper). See MetricsProbePayload docstrings.
+
+    def _avg_nonzero(self, vals: list[float]) -> float:
+        vals = [v for v in vals if v > 0]
+        return sum(vals) / len(vals) if vals else 0.0
+
+    def stats_avg_downlink_half_ms(self) -> float:
+        return self._avg_nonzero([p.downlink_half_ms() for p in self.probe_stats])
+
+    def stats_avg_node_processing_ms(self) -> float:
+        return self._avg_nonzero(
+            [p.node_processing_ms() for p in self.probe_stats]
+        )
+
+    def stats_avg_uplink_half_ms(self) -> float:
+        return self._avg_nonzero([p.uplink_half_ms() for p in self.probe_stats])
+
+    def stats_avg_wire_rtt_ms(self) -> float:
+        return self._avg_nonzero([p.wire_rtt_ms() for p in self.probe_stats])
+
+    def stats_avg_host_overhead_ms(self) -> float:
+        """Host-side overhead = host RTT - wire RTT.
+
+        Captures UART round-trip + small gateway-internal time +
+        Python parse overhead. At 1 Mbps UART this is typically
+        10-30 ms. Sustained higher values suggest UART congestion at
+        the gateway, lock contention on the edge, or GIL pressure.
+
+        Returns 0 if either host RTT or wire RTT are unavailable, or
+        if their difference is negative (which shouldn't happen with
+        the monotonic-clock fix in MetricsTester.timestamp_us; clamp
+        defensively)."""
+        host = self.stats_avg_latency_roundtrip_node_edge_ms()
+        wire = self.stats_avg_wire_rtt_ms()
+        if host <= 0 or wire <= 0:
+            return 0.0
+        return max(0.0, host - wire)
+
+    def stats_queue_depth_slotframes(self, sf_duration_ms: float) -> float:
+        """Estimated TX-queue depth at the node, in slotframe units.
+
+        Each joined node has exactly one U slot per slotframe (Mari paper,
+        §3.5 / Table 1), so the uplink half of the probe RTT divided by
+        the slotframe duration is the number of packets queued ahead of
+        the probe response when it was enqueued. Sustained values > 1
+        indicate contention, > 3 is real saturation. Returns 0 when
+        slotframe duration is unknown.
+        """
+        if sf_duration_ms <= 0:
+            return 0.0
+        return self.stats_avg_uplink_half_ms() / sf_duration_ms
+
+    def stats_uplink_utilization(self, sf_duration_ms: float) -> float:
+        """Fraction of this node's max sustainable uplink rate currently used.
+
+        max_pps_per_node = 1000 / sf_duration_ms (one U slot per
+        slotframe in the current shipped schedules). Observed pps is
+        the 1-second RX rate at the edge, which equals the drain rate
+        from the node's TX queue. >0.9 means the node is at or near
+        saturation: any extra production will pile up in the queue.
+        """
+        if sf_duration_ms <= 0:
+            return 0.0
+        max_pps = 1000.0 / sf_duration_ms
+        observed_pps = self.stats.received_count(1, include_test_packets=True)
+        return observed_pps / max_pps
+
     def register_received_frame(self, frame: Frame):
         self.stats.add_received(frame)
 
@@ -504,6 +574,27 @@ class MariGateway:
             self.nodes
         )
         return res if res >= 0 else 0.0
+
+    # Network-level averages of the ASN-decomposed latency, skipping
+    # nodes that haven't produced a usable sample yet.
+    def _avg_node_metric_nonzero(self, fn) -> float:
+        vals = [fn(n) for n in self.nodes]
+        vals = [v for v in vals if v > 0]
+        return sum(vals) / len(vals) if vals else 0.0
+
+    def stats_avg_downlink_half_ms(self) -> float:
+        return self._avg_node_metric_nonzero(MariNode.stats_avg_downlink_half_ms)
+
+    def stats_avg_node_processing_ms(self) -> float:
+        return self._avg_node_metric_nonzero(
+            MariNode.stats_avg_node_processing_ms
+        )
+
+    def stats_avg_uplink_half_ms(self) -> float:
+        return self._avg_node_metric_nonzero(MariNode.stats_avg_uplink_half_ms)
+
+    def stats_avg_host_overhead_ms(self) -> float:
+        return self._avg_node_metric_nonzero(MariNode.stats_avg_host_overhead_ms)
 
     def stats_avg_latency_roundtrip_node_cloud_ms(self) -> float:
         if not self.nodes:

--- a/marilib/tui_edge.py
+++ b/marilib/tui_edge.py
@@ -10,7 +10,13 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
-from marilib.model import MariNode, TestState
+from marilib.model import SCHEDULES, MariNode, TestState
+
+# Per-node TX-queue depth (in slotframes) above which we color the
+# value yellow (mild contention) or red (real saturation). Same
+# thresholds apply to the network-wide warning in the header.
+QUEUE_DEPTH_WARN_SF = 2.0
+QUEUE_DEPTH_BAD_SF = 4.0
 from marilib.tui import MarilibTUI
 
 if TYPE_CHECKING:
@@ -135,6 +141,55 @@ class MarilibTUIEdge(MarilibTUI):
         if has_latency_info:
             status.append("Latency:  ", style="bold yellow")
             status.append(f"Avg: {avg_latency_edge:.1f}ms")
+            # Network-wide latency breakdown. Four legs sum ≈ host RTT;
+            # see MetricsProbePayload and MariNode docstrings for what
+            # each term covers. Red on the largest term so the eye
+            # lands on the bottleneck.
+            host_ms = mari.gateway.stats_avg_host_overhead_ms()
+            dl_ms = mari.gateway.stats_avg_downlink_half_ms()
+            app_ms = mari.gateway.stats_avg_node_processing_ms()
+            ul_ms = mari.gateway.stats_avg_uplink_half_ms()
+            if dl_ms or app_ms or ul_ms:
+                worst = max(host_ms, dl_ms, app_ms, ul_ms)
+
+                def fmt(v):
+                    s = f"{v:.0f}"
+                    return f"[red]{s}[/red]" if v == worst and worst > 0 else s
+
+                # Text.append doesn't parse markup (only Table cells do);
+                # build a Text via from_markup so the [red] tags render.
+                status.append_text(
+                    Text.from_markup(
+                        f" (host: {fmt(host_ms)}  dl: {fmt(dl_ms)}  app: {fmt(app_ms)}  ul: {fmt(ul_ms)} ms)"
+                    )
+                )
+
+            # Saturation warning. Flag the worst node's TX-queue depth in
+            # slotframes — if any node's queue is multiple slotframes deep,
+            # the operator should see it without scanning the per-node
+            # table. Thresholds match the per-node coloring above.
+            sched_h = SCHEDULES.get(mari.gateway.info.schedule_id)
+            sf_dur_h = float(sched_h["sf_duration"]) if sched_h else 0.0
+            if sf_dur_h > 0 and mari.gateway.nodes:
+                worst_q = max(
+                    (
+                        n.stats_queue_depth_slotframes(sf_dur_h)
+                        for n in mari.gateway.nodes
+                    ),
+                    default=0.0,
+                )
+                if worst_q >= QUEUE_DEPTH_BAD_SF:
+                    status.append_text(
+                        Text.from_markup(
+                            f"  [red bold]⚠ TX queue saturated (worst {worst_q:.1f} sf)[/]"
+                        )
+                    )
+                elif worst_q >= QUEUE_DEPTH_WARN_SF:
+                    status.append_text(
+                        Text.from_markup(
+                            f"  [yellow]⚠ TX queue contended (worst {worst_q:.1f} sf)[/]"
+                        )
+                    )
 
         # Display PDR
         status.append(f"{pdr_info}{radio_pdr_info}{uart_pdr_info}")
@@ -159,7 +214,12 @@ class MarilibTUIEdge(MarilibTUI):
             border_style="blue",
         )
 
-    def create_nodes_table(self, nodes: list[MariNode], title="") -> Table:
+    def create_nodes_table(
+        self,
+        nodes: list[MariNode],
+        title="",
+        sf_duration_ms: float = 0.0,
+    ) -> Table:
         table = Table(
             show_header=True,
             header_style="bold cyan",
@@ -175,14 +235,58 @@ class MarilibTUIEdge(MarilibTUI):
         table.add_column("Radio ↓ PDR | RSSI", justify="center")
         table.add_column("Radio ↑ PDR | RSSI", justify="center")
         table.add_column("UART PDR ↓ | ↑", justify="center")
-        table.add_column("Latency", justify="center")
+        table.add_column("Latency | host/dl/app/ul (ms)", justify="center")
+        table.add_column("TX queue (sf)", justify="right")
 
         for node in nodes:
-            lat_str = (
-                f"{node.stats_avg_latency_roundtrip_node_edge_ms():.1f} ms"
-                if node.stats_avg_latency_roundtrip_node_edge_ms() > 0
-                else "..."
-            )
+            # Combined latency cell: total host RTT on the left, then
+            # the four-leg breakdown (host overhead, dl, app, ul) on
+            # the right. host overhead = host RTT - wire RTT (UART
+            # round-trip + Python parse); dl/app/ul are the wire-side
+            # ASN-decomposed legs. Sum of the four ≈ total host RTT.
+            # When no probe samples exist yet, show "...". When the
+            # host RTT is known but the firmware hasn't populated the
+            # wire ASNs yet, show the total with "?" for the legs.
+            host_rtt = node.stats_avg_latency_roundtrip_node_edge_ms()
+            dl_ms = node.stats_avg_downlink_half_ms()
+            app_ms = node.stats_avg_node_processing_ms()
+            ul_ms = node.stats_avg_uplink_half_ms()
+            host_ms = node.stats_avg_host_overhead_ms()
+            wire_available = (dl_ms or app_ms or ul_ms) and host_rtt > 0
+            if wire_available:
+                # Color the largest of the four legs red so the eye
+                # lands on the bottleneck. Ties resolve to the latest
+                # in host/dl/app/ul order.
+                worst = max(host_ms, dl_ms, app_ms, ul_ms)
+                parts = []
+                for label_val in [host_ms, dl_ms, app_ms, ul_ms]:
+                    s = f"{label_val:.0f}"
+                    if label_val == worst and worst > 0:
+                        s = f"[red]{s}[/red]"
+                    parts.append(s)
+                lat_str = (
+                    f"{host_rtt:.0f} | "
+                    f"{parts[0]} / {parts[1]} / {parts[2]} / {parts[3]}"
+                )
+            elif host_rtt > 0:
+                lat_str = f"{host_rtt:.0f} | ? / ? / ? / ?"
+            else:
+                lat_str = "..."
+
+            # Node TX-queue depth in slotframes (1 U slot per node per
+            # slotframe → ul_ms / sf_duration_ms ≈ packets queued ahead
+            # of the probe response). Needs the gateway's slotframe
+            # duration, passed in from create_nodes_panel.
+            if sf_duration_ms > 0 and ul_ms > 0:
+                q_sf = node.stats_queue_depth_slotframes(sf_duration_ms)
+                if q_sf >= QUEUE_DEPTH_BAD_SF:
+                    q_str = f"[red]{q_sf:.1f}[/red]"
+                elif q_sf >= QUEUE_DEPTH_WARN_SF:
+                    q_str = f"[yellow]{q_sf:.1f}[/yellow]"
+                else:
+                    q_str = f"{q_sf:.1f}"
+            else:
+                q_str = "..."
             # PDR Downlink with color coding
             if node.stats_pdr_downlink_radio() > 0:
                 if node.stats_pdr_downlink_radio() > 0.9:
@@ -247,12 +351,15 @@ class MarilibTUIEdge(MarilibTUI):
                 f"{pdr_up_str} | {rssi_gw_str} dBm",
                 f"{pdr_down_gw_edge_str} | {pdr_up_gw_edge_str}",
                 lat_str,
+                q_str,
             )
         return table
 
     def create_nodes_panel(self, mari: "MarilibEdge") -> Panel:
         """Create the panel that contains the nodes table."""
         nodes = mari.gateway.nodes
+        sched = SCHEDULES.get(mari.gateway.info.schedule_id)
+        sf_duration_ms = float(sched["sf_duration"]) if sched else 0.0
         max_rows = self.get_max_rows()
         max_displayable_nodes = self.max_tables * max_rows
         nodes_to_display = nodes[:max_displayable_nodes]
@@ -263,7 +370,11 @@ class MarilibTUIEdge(MarilibTUI):
             current_table_nodes.append(node)
             if len(current_table_nodes) == max_rows or i == len(nodes_to_display) - 1:
                 title = f"Nodes {i - len(current_table_nodes) + 2}-{i + 1}"
-                tables.append(self.create_nodes_table(current_table_nodes, title))
+                tables.append(
+                    self.create_nodes_table(
+                        current_table_nodes, title, sf_duration_ms
+                    )
+                )
                 current_table_nodes = []
                 if len(tables) >= self.max_tables:
                     break

--- a/marilib/tui_edge.py
+++ b/marilib/tui_edge.py
@@ -238,8 +238,10 @@ class MarilibTUIEdge(MarilibTUI):
         table.add_column("Radio ↓ PDR | RSSI", justify="center")
         table.add_column("Radio ↑ PDR | RSSI", justify="center")
         table.add_column("UART PDR ↓ | ↑", justify="center")
+        # Latency breakdown and Q (sf) are explained in the
+        # "Reading the TUI" section of README.md.
         table.add_column("Latency | host/dl/app/ul (ms)", justify="center")
-        table.add_column("TX queue (sf)", justify="right")
+        table.add_column("Q (sf)", justify="right")
 
         for node in nodes:
             # Combined latency cell: total host RTT on the left, then

--- a/marilib/tui_edge.py
+++ b/marilib/tui_edge.py
@@ -171,10 +171,7 @@ class MarilibTUIEdge(MarilibTUI):
             sf_dur_h = float(sched_h["sf_duration"]) if sched_h else 0.0
             if sf_dur_h > 0 and mari.gateway.nodes:
                 worst_q = max(
-                    (
-                        n.stats_queue_depth_slotframes(sf_dur_h)
-                        for n in mari.gateway.nodes
-                    ),
+                    (n.stats_queue_depth_slotframes(sf_dur_h) for n in mari.gateway.nodes),
                     default=0.0,
                 )
                 if worst_q >= QUEUE_DEPTH_BAD_SF:
@@ -269,10 +266,7 @@ class MarilibTUIEdge(MarilibTUI):
                     if label_val == worst and worst > 0:
                         s = f"[red]{s}[/red]"
                     parts.append(s)
-                lat_str = (
-                    f"{host_rtt:.0f} | "
-                    f"{parts[0]} / {parts[1]} / {parts[2]} / {parts[3]}"
-                )
+                lat_str = f"{host_rtt:.0f} | {parts[0]} / {parts[1]} / {parts[2]} / {parts[3]}"
             elif host_rtt > 0:
                 lat_str = f"{host_rtt:.0f} | ? / ? / ? / ?"
             else:
@@ -375,11 +369,7 @@ class MarilibTUIEdge(MarilibTUI):
             current_table_nodes.append(node)
             if len(current_table_nodes) == max_rows or i == len(nodes_to_display) - 1:
                 title = f"Nodes {i - len(current_table_nodes) + 2}-{i + 1}"
-                tables.append(
-                    self.create_nodes_table(
-                        current_table_nodes, title, sf_duration_ms
-                    )
-                )
+                tables.append(self.create_nodes_table(current_table_nodes, title, sf_duration_ms))
                 current_table_nodes = []
                 if len(tables) >= self.max_tables:
                     break

--- a/marilib/tui_edge.py
+++ b/marilib/tui_edge.py
@@ -11,16 +11,16 @@ from rich.table import Table
 from rich.text import Text
 
 from marilib.model import SCHEDULES, MariNode, TestState
+from marilib.tui import MarilibTUI
+
+if TYPE_CHECKING:
+    from marilib.marilib_edge import MarilibEdge
 
 # Per-node TX-queue depth (in slotframes) above which we color the
 # value yellow (mild contention) or red (real saturation). Same
 # thresholds apply to the network-wide warning in the header.
 QUEUE_DEPTH_WARN_SF = 2.0
 QUEUE_DEPTH_BAD_SF = 4.0
-from marilib.tui import MarilibTUI
-
-if TYPE_CHECKING:
-    from marilib.marilib_edge import MarilibEdge
 
 
 class MarilibTUIEdge(MarilibTUI):

--- a/marilib/tui_edge.py
+++ b/marilib/tui_edge.py
@@ -124,7 +124,6 @@ class MarilibTUIEdge(MarilibTUI):
         avg_radio_pdr_up = mari.gateway.stats_avg_pdr_uplink_radio()
         has_radio_pdr_info = avg_radio_pdr_down > 0 or avg_radio_pdr_up > 0
 
-        pdr_info = "  |  PDR:" if has_uart_pdr_info or has_radio_pdr_info else ""
         radio_pdr_info = (
             f"  Radio ↓ {avg_radio_pdr_down:.1%} ↑ {avg_radio_pdr_up:.1%}"
             if has_radio_pdr_info
@@ -140,7 +139,7 @@ class MarilibTUIEdge(MarilibTUI):
         # Display Latency
         if has_latency_info:
             status.append("Latency:  ", style="bold yellow")
-            status.append(f"Avg: {avg_latency_edge:.1f}ms")
+            status.append(f"Avg: {avg_latency_edge:.1f} ms")
             # Network-wide latency breakdown. Four legs sum ≈ host RTT;
             # see MetricsProbePayload and MariNode docstrings for what
             # each term covers. Red on the largest term so the eye
@@ -191,10 +190,14 @@ class MarilibTUIEdge(MarilibTUI):
                         )
                     )
 
-        # Display PDR
-        status.append(f"{pdr_info}{radio_pdr_info}{uart_pdr_info}")
+        # Display PDR — match the bold-yellow style of Latency/Stats so
+        # all three metric labels look consistent.
+        if has_uart_pdr_info or has_radio_pdr_info:
+            status.append("  |  ")
+            status.append("PDR:", style="bold yellow")
+            status.append(f"{radio_pdr_info}{uart_pdr_info}")
 
-        status.append("\n\nStats:    ", style="bold yellow")
+        status.append("\n\nStats:  ", style="bold yellow")
         if self.test_state and self.test_state.load > 0 and self.test_state.rate > 0:
             status.append(
                 "Test load: ",
@@ -204,7 +207,7 @@ class MarilibTUIEdge(MarilibTUI):
 
         stats = mari.gateway.stats
         status.append(f"Frames TX: {stats.sent_count(include_test_packets=True)}  |  ")
-        status.append(f"Frames RX: {stats.received_count(include_test_packets=True)} |  ")
+        status.append(f"Frames RX: {stats.received_count(include_test_packets=True)}  |  ")
         status.append(f"TX/s: {stats.sent_count(1, include_test_packets=True)}  |  ")
         status.append(f"RX/s: {stats.received_count(1, include_test_packets=True)}")
 


### PR DESCRIPTION
## Description

Make latency more accurate at python side, a bunch of TUI improvements.

---

## Testing of Node / Gateway (if applicable)

- I tested this change with `_1_` nodes and `_1_` gateways.
- I let it run for the following amount of time: `_10_` minutes
